### PR TITLE
Add support for any version name in local docker build 

### DIFF
--- a/docker-files/siddhi-runner/alpine/README.md
+++ b/docker-files/siddhi-runner/alpine/README.md
@@ -27,7 +27,7 @@ For the base, navigate to `<DOCKERFILE_HOME>/base` directory. You can create the
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x .
 ```
 
-You can also build a Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, your pack name should be the same as `${RUNTIME_SERVER_PACK}.zip`. After that, you can run the following command to build the Siddhi runner image.
+You can also build a Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. After that, you can run the following command to build the Siddhi runner image.
 
 ```sh
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x .

--- a/docker-files/siddhi-runner/alpine/README.md
+++ b/docker-files/siddhi-runner/alpine/README.md
@@ -27,7 +27,7 @@ For the base, navigate to `<DOCKERFILE_HOME>/base` directory. You can create the
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x .
 ```
 
-You can also build Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner pack to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, you have to rename Siddhi runner pack name as `siddhi-runner`. After that, you can run the following command to build the Siddhi runner image.
+You can also build a Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, your pack name should be the same as `${RUNTIME_SERVER_PACK}.zip`. After that, you can run the following command to build the Siddhi runner image.
 
 ```sh
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x .

--- a/docker-files/siddhi-runner/alpine/base/Dockerfile
+++ b/docker-files/siddhi-runner/alpine/base/Dockerfile
@@ -58,10 +58,11 @@ RUN \
 
 COPY --chown=siddhi_user:siddhi_io ${FILES}/${PACK}/ ${USER_HOME}/
 # download Siddhi Runner Distribution
-RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER} ] ; then wget --no-check-certificate -O ${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
-    && unzip -d ${USER_HOME} ${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
-    && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} \
-    && rm -f ${RUNTIME_SERVER_PACK}.zip ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi
+RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
+    ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi
+
+RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
+    && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} && rm -f {USER_HOME}/${RUNTIME_SERVER_PACK}.zip
 
 # set the user and work directory
 USER ${USER_ID}

--- a/docker-files/siddhi-runner/alpine/base/Dockerfile
+++ b/docker-files/siddhi-runner/alpine/base/Dockerfile
@@ -58,10 +58,10 @@ RUN \
 
 COPY --chown=siddhi_user:siddhi_io ${FILES}/${PACK}/ ${USER_HOME}/
 # download Siddhi Runner Distribution
-RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
-    ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi
+RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER}*.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
+    ; else echo "Using Local image "; fi
 
-RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
+RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER}*.zip && for file in ${USER_HOME}/${RUNTIME_SERVER}*; do mv $file ${USER_HOME}/${RUNTIME_SERVER}; done \
     && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} && rm -f {USER_HOME}/${RUNTIME_SERVER_PACK}.zip
 
 # set the user and work directory

--- a/docker-files/siddhi-runner/ubuntu/README.md
+++ b/docker-files/siddhi-runner/ubuntu/README.md
@@ -27,7 +27,7 @@ For the base, navigate to `<DOCKERFILE_HOME>/base` directory. You can create the
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x . 
 ```
 
-You can also build Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner pack to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, you have to rename Siddhi runner pack name as `siddhi-runner`. After that, you can run the following command to build the Siddhi runner image.
+You can also build a Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, your pack name should be the same as `${RUNTIME_SERVER_PACK}.zip`. After that, you can run the following command to build the Siddhi runner image.
 
 ```sh
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x . 

--- a/docker-files/siddhi-runner/ubuntu/README.md
+++ b/docker-files/siddhi-runner/ubuntu/README.md
@@ -27,7 +27,7 @@ For the base, navigate to `<DOCKERFILE_HOME>/base` directory. You can create the
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x . 
 ```
 
-You can also build a Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, your pack name should be the same as `${RUNTIME_SERVER_PACK}.zip`. After that, you can run the following command to build the Siddhi runner image.
+You can also build a Siddhi runner docker image in local mode, which means here it uses a local Siddhi runner pack instead of downloading from GitHub. To do that you have to copy the local Siddhi runner zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. After that, you can run the following command to build the Siddhi runner image.
 
 ```sh
 docker build -t siddhiio/siddhi-runner-base-alpine:5.1.x . 

--- a/docker-files/siddhi-runner/ubuntu/base/Dockerfile
+++ b/docker-files/siddhi-runner/ubuntu/base/Dockerfile
@@ -63,10 +63,10 @@ RUN \
 
 COPY --chown=siddhi_user:siddhi_io ${FILES}/${PACK}/ ${USER_HOME}/
 # download Siddhi Runner Distribution
-RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
-    ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi
+RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}*.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
+    ; else echo "Using Local image "; fi
 
-RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
+RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER}*.zip && for file in ${USER_HOME}/${RUNTIME_SERVER}*; do mv $file ${USER_HOME}/${RUNTIME_SERVER}; done \
     && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} && rm -f {USER_HOME}/${RUNTIME_SERVER_PACK}.zip
 
 # set the user and work directory

--- a/docker-files/siddhi-runner/ubuntu/base/Dockerfile
+++ b/docker-files/siddhi-runner/ubuntu/base/Dockerfile
@@ -63,10 +63,11 @@ RUN \
 
 COPY --chown=siddhi_user:siddhi_io ${FILES}/${PACK}/ ${USER_HOME}/
 # download Siddhi Runner Distribution
-RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER} ] ; then wget --no-check-certificate -O ${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
-    && unzip -d ${USER_HOME} ${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
-    && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} \
-    && rm -f ${RUNTIME_SERVER_PACK}.zip ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi
+RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
+    ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi
+
+RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
+    && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} && rm -f {USER_HOME}/${RUNTIME_SERVER_PACK}.zip
 
 # set the user and work directory
 USER ${USER_ID}

--- a/docker-files/siddhi-tooling/ubuntu/README.md
+++ b/docker-files/siddhi-tooling/ubuntu/README.md
@@ -27,7 +27,7 @@ For the base, navigate to `<DOCKERFILE_HOME>/base` directory. You can create the
 docker build -t siddhiio/siddhi-tooling-base:5.1.x . 
 ```
 
-You can also build a Siddhi tooling docker image in local mode, which means here it uses a local Siddhi tooling pack instead of downloading from GitHub. To do that you have to copy the local Siddhi tooling zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, your pack name should be the same as `${RUNTIME_SERVER_PACK}.zip`. After that, you can run the following command to build the Siddhi tooling image.
+You can also build a Siddhi tooling docker image in local mode, which means here it uses a local Siddhi tooling pack instead of downloading from GitHub. To do that you have to copy the local Siddhi tooling zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. After that, you can run the following command to build the Siddhi tooling image.
 
 ```sh
 docker build -t siddhiio/siddhi-tooling-base:5.1.x .

--- a/docker-files/siddhi-tooling/ubuntu/README.md
+++ b/docker-files/siddhi-tooling/ubuntu/README.md
@@ -27,7 +27,7 @@ For the base, navigate to `<DOCKERFILE_HOME>/base` directory. You can create the
 docker build -t siddhiio/siddhi-tooling-base:5.1.x . 
 ```
 
-You can also build Siddhi tooling docker image in local mode, which means here it uses a local Siddhi tooling pack instead of downloading from GitHub. To do that you have to copy the local Siddhi tooling pack to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, you have to rename Siddhi tooling pack name as `siddhi-tooling`. After that, you can run the following command to build the Siddhi tooling image.
+You can also build a Siddhi tooling docker image in local mode, which means here it uses a local Siddhi tooling pack instead of downloading from GitHub. To do that you have to copy the local Siddhi tooling zip file to `<DOCKERFILE_HOME>/base/files/pack` directory. Note that, your pack name should be the same as `${RUNTIME_SERVER_PACK}.zip`. After that, you can run the following command to build the Siddhi tooling image.
 
 ```sh
 docker build -t siddhiio/siddhi-tooling-base:5.1.x .

--- a/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
+++ b/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
@@ -75,10 +75,10 @@ ENV PATH ${PATH}:/opt/ant/bin
 
 COPY --chown=siddhi_user:siddhi_io ${FILES}/${PACK}/ ${USER_HOME}/
 # download Siddhi Tooling Distribution
-RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
-    ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi 
+RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}*.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
+    ; else echo "Using Local image "; fi 
     
-RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
+RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER}*.zip && for file in ${USER_HOME}/${RUNTIME_SERVER}*; do mv $file ${USER_HOME}/${RUNTIME_SERVER}; done \
     && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} && rm -f {USER_HOME}/${RUNTIME_SERVER_PACK}.zip
 
 # set the user and work directory

--- a/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
+++ b/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
@@ -75,10 +75,11 @@ ENV PATH ${PATH}:/opt/ant/bin
 
 COPY --chown=siddhi_user:siddhi_io ${FILES}/${PACK}/ ${USER_HOME}/
 # download Siddhi Tooling Distribution
-RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER} ] ; then wget --no-check-certificate -O ${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
-    && unzip -d ${USER_HOME} ${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
-    && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} \
-    && rm -f ${RUNTIME_SERVER_PACK}.zip ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi
+RUN if [ ! -e ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip ] ; then wget --no-check-certificate -O ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip "https://github.com/siddhi-io/distribution/releases/download/v${RUNTIME_SERVER_VERSION}/${RUNTIME_SERVER_PACK}.zip" \
+    ; else echo "Using Local image " ${USER_HOME}/${RUNTIME_SERVER}; fi 
+    
+RUN unzip -d ${USER_HOME} ${USER_HOME}/${RUNTIME_SERVER_PACK}.zip && mv ${USER_HOME}/${RUNTIME_SERVER_PACK} ${RUNTIME_SERVER_HOME} \
+    && chown ${USER}:${USER_GROUP} -R ${RUNTIME_SERVER_HOME} && rm -f {USER_HOME}/${RUNTIME_SERVER_PACK}.zip
 
 # set the user and work directory
 USER ${USER_ID}


### PR DESCRIPTION
## Purpose
- For the local build, we will be able to use a zip file with any version name.

## Goals
Support successful docker builds for any version of the Siddhi runner pack.

## Approach
- Always(local or release mode) copy a zip file to the home directory in the container to be built.
- Extract the zip file and rename the extracted directory to `siddhi-runner`.

## User stories
- For local builds, the user just needs to add any pack(zip file) to the `base/files/pack` directory.

## Related PRs
https://github.com/siddhi-io/docker-siddhi/pull/22

## Test environment
Docker client and server version 19.03.2
