### PR TITLE
Fix for Javascript functions not working with Siddhi-docker

### DIFF
--- a/docker-files/siddhi-runner/alpine/base/Dockerfile
+++ b/docker-files/siddhi-runner/alpine/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Alpine Docker image
-FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine-slim
+FROM adoptopenjdk/openjdk8:jdk8u222-b10-alpine
 MAINTAINER Siddhi IO Docker Maintainers "siddhi-dev@googlegroups.com"
 
 # set user configurations

--- a/docker-files/siddhi-runner/ubuntu/base/Dockerfile
+++ b/docker-files/siddhi-runner/ubuntu/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-slim
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER Siddhi IO Docker Maintainers "siddhi-dev@googlegroups.com"
 
 # set user configurations

--- a/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
+++ b/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12-slim
+FROM adoptopenjdk/openjdk8:jdk8u192-b12
 MAINTAINER Siddhi IO Docker Maintainers "siddhi-dev@googlegroups.com"
 
 # set user configurations


### PR DESCRIPTION
## Purpose
> Slim version of base JDK image doesn't include the NashornScript libraries for Javascript evaluation, thus causing exceptions while deploying the siddhi scripts using the siddhi-runner or siddhi-tooling docker images.

## Goals
> The base image now points to a not slim JDK version which includes the NashornScript libraries required for evaluating JS functions in Siddhi scripts.
