### PR TITLE
[dependencies] js:eval error & download link invalid.

### DIFF
--- a/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
+++ b/docker-files/siddhi-tooling/ubuntu/base/Dockerfile
@@ -17,7 +17,7 @@
 # ------------------------------------------------------------------------
 
 # set base Docker image to AdoptOpenJDK Ubuntu Docker image
-FROM adoptopenjdk/openjdk8:jdk8u192-b12
+FROM adoptopenjdk/openjdk8:jdk8u312-b07
 MAINTAINER Siddhi IO Docker Maintainers "siddhi-dev@googlegroups.com"
 
 # set user configurations
@@ -62,9 +62,9 @@ RUN \
     && echo '[ ! -z "${TERM}" -a -r /etc/motd ] && cat /etc/motd' >> /etc/bash.bashrc; echo "${MOTD}" > /etc/motd
 
 # install ant
-ENV ANT_VERSION 1.10.6
+ENV ANT_VERSION 1.10.12
 RUN cd && \
-    wget -q http://www.us.apache.org/dist//ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
+    wget -q https://dlcdn.apache.org//ant/binaries/apache-ant-${ANT_VERSION}-bin.tar.gz && \
     tar -xzf apache-ant-${ANT_VERSION}-bin.tar.gz && \
     mv apache-ant-${ANT_VERSION} /opt/ant && \
     rm apache-ant-${ANT_VERSION}-bin.tar.gz


### PR DESCRIPTION
## Purpose
Resolves https://github.com/siddhi-io/docker-siddhi/issues/35

## Goals
- fix siddhi-tooling-base build failed
- fix js:eval error

## Approach
- update openjdk image version
- update apache-ant download link 
- update apache-ant version from **1.10.6 -> 1.10.12**

## User stories
issues https://github.com/siddhi-io/docker-siddhi/issues/32  and pr https://github.com/siddhi-io/docker-siddhi/pull/33
After referring to these, I realized that the reason may be openjdk docker image, and found effective links while repairing.

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
https://github.com/siddhi-io/docker-siddhi/issues/35

## Training
https://github.com/siddhi-io/docker-siddhi/issues/35

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
https://github.com/siddhi-io/docker-siddhi/issues/32


## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
JDK:  docker image adoptopenjdk/openjdk8:jdk8u312-b07
database: docker mysql:5.7
browser: Google Chrome Version 95.0.4638.69 (Official Build) (x86_64)


## Learning
https://github.com/siddhi-io/docker-siddhi/issues/32
https://github.com/siddhi-io/docker-siddhi/pull/33
https://siddhi.io/en/v5.1/download/#512
https://ant.apache.org/bindownload.cgi
https://stackoverflow.com/a/24326540
https://siddhi-io.github.io/siddhi-map-json/
